### PR TITLE
Show good commenting practice

### DIFF
--- a/01_python_basic_calculator.ipynb
+++ b/01_python_basic_calculator.ipynb
@@ -365,6 +365,81 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div style=\"display: flex; justify-content: space-between;\">\n",
+    "<div style=\"width: 48%; line-height: 1.5;\">\n",
+    "\n",
+    "####  ...but not excessively! \n",
+    "\n",
+    "In reality, though, don't comment every individual statement. A good comment does not state what the code obviously does.\n",
+    "</div>\n",
+    "<div style=\"width: 4%;\">\n",
+    "</div>\n",
+    "<div style=\"width: 48%; line-height: 1.5;color: grey;\">\n",
+    "\n",
+    "####  ...aber nicht exzessiv!\n",
+    "\n",
+    "In der Praxis sollten Sie nicht jede einzelne Anweisung kommentieren. Ein guter Kommentar beschreibt nicht, was das Programm offensichtlicherweise macht.\n",
+    "</div>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div style=\"display: flex; justify-content: space-between;\">\n",
+    "<div style=\"width: 48%; line-height: 1.5;\">\n",
+    "More realistic example with function docstring: \n",
+    "</div>\n",
+    "<div style=\"width: 4%;\">\n",
+    "</div>\n",
+    "<div style=\"width: 48%; line-height: 1.3;color: grey;\">\n",
+    "Realistischeres Beispiel mit Dokumentationsstring der Funktion: \n",
+    "</div>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "120\n"
+     ]
+    }
+   ],
+   "source": [
+    "def factorial(n):\n",
+    "    \"\"\"\n",
+    "    Compute the factorial of a non-negative integer n.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    n : int\n",
+    "        The number to compute the factorial of.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    result : int\n",
+    "        The factorial of n.\n",
+    "    \"\"\"\n",
+    "    result = 1\n",
+    "    while n > 0:\n",
+    "        result *= n\n",
+    "        n -= 1\n",
+    "    return result\n",
+    "\n",
+    "print(factorial(5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Integer (`int`)"
    ]
   },


### PR DESCRIPTION
I think the commenting example in `01_python_basic_calculator.ipynb` is too extreme. In the end, people should give a global description for functions and comment non-obvious code statements.